### PR TITLE
lang/fr: fixed some mistakes (and nonsense changes)

### DIFF
--- a/fr.yml
+++ b/fr.yml
@@ -222,7 +222,7 @@ app:
       description: "Windhawk requière des droits administrateur, mais pour un ordinateur ne comportant qu'un seul utilisateur, avoir l'invite de contrôle du compte d'utilisateur (UAC) à chaque fois peut être ennuyant, donc Windhawk la contourne. Activer cette option pour exiger l'invite de contrôle du compte de l'utilisateur (UAC) pour lancer Windhawk."
     dontAutoShowToolkit:
       title: "Ne pas automatiquement afficher la boîte de dialogue de la boîte à outils"
-      description: "Par défaut, Windhawk affiche automatiquement la boîte de dialogue de la boîte à outils quand il détecte que la barre des tâches n'est pas accessible, à cause d'instabilités système ou autre. La boîte de dialogue permet de quitter Windhawk, passer en mode sans échec and effectuer d'autres opérations. Elle peut également être afficher à l'aide du raccourci clavier Ctrl+Win+W."
+      description: "Par défaut, Windhawk affiche automatiquement la boîte de dialogue de la boîte à outils quand il détecte que la barre des tâches n'est pas accessible, à cause d'instabilités système ou autre. La boîte de dialogue permet de quitter Windhawk, passer en mode sans échec et effectuer d'autres opérations. Elle peut également être afficher à l'aide du raccourci clavier Ctrl+Win+W."
     modInitDialogDelay:
       title: "Délai de dialogue d'initialisation du mod"
       description: "Temps en millisecondes à attendre avant d'afficher les boîte de dialogue de progression pour initialiser le mod."

--- a/fr.yml
+++ b/fr.yml
@@ -9,9 +9,9 @@ setup:
   OPEN_PROGRAM: "Lancer $(^NameDA)"
   CLEANCONFIRM: "&Supprimer les paramètres du programme"
   INSTALLED_HEADER: "Déjà installé"
-  INSTALLED_TEXT: "Selectionnez l'action à effectuer"
-  INSTALLED_SAME: "$(^NameDA) v${VERSION} est déjà installé. Selectionnez l'action que vous voulez effectuer."
-  INSTALLED_OLD: "Une ancienne version de $(^NameDA) est installée sur votre système. Selectionnez l'action que vous voulez effectuer."
+  INSTALLED_TEXT: "Sélectionnez l'action à effectuer"
+  INSTALLED_SAME: "$(^NameDA) v${VERSION} est déjà installé. Sélectionnez l'action que vous voulez effectuer."
+  INSTALLED_OLD: "Une ancienne version de $(^NameDA) est installée sur votre système. Sélectionnez l'action que vous voulez effectuer."
   INSTALLED_NEW: "Une version plus récente de $(^NameDA) est déjà installée ! Il n'est pas recommandé d'installer une version plus ancienne. Si vous voulez réellement installer cette version plus ancienne, il est recommandé de désinstaller en premier la version actuelle. Sélectionnez l'action que vous voulez effectuer."
   REINSTALL: "&Réinstaller"
   UPDATE: "&Mettre à jour"
@@ -24,7 +24,7 @@ setup:
   INSTTYPE_STANDARD: "&Installation standard (recommandé)"
   INSTTYPE_STANDARD_DESC: "Installer $(^NameDA) pour tous les utilisateurs de cette machine."
   INSTTYPE_PORTABLE: "&Installation portable"
-  INSTTYPE_PORTABLE_DESC: "Extraire une version portable de $(^NameDA). En mode portable, toutes les données de configuration sont stockées dans le dossier de l'application et aucune des informations n'est écrite dans le registre."
+  INSTTYPE_PORTABLE_DESC: "Extraire une version portable de $(^NameDA). En mode portable, toutes les données de configuration sont stockées dans le dossier de l'application et aucune information n'est écrite dans le registre."
   EXTRACTING_FILES: "Extraction des fichiers... %s"
   INETC_DOWNLOADING: "Téléchargement %s"
   INETC_CONNECTING: "Connexion..."
@@ -171,7 +171,7 @@ app:
         descriptionInclusion: "Une liste personnalisée de noms/chemins de processus supplémentaires que le mod va inclure dans le ciblage. Cette liste est ajoutée à la liste d'inclusion que l'auteur du mod a défini pour déterminer quel processus cibler. Pour chaque processus, le mod est chargé si le chemin du processus correspond à l'un de ceux inclus et ne correspond à aucune de ceux exclus."
         titleExclusion: "Liste de processus exclus personnalisée"
         descriptionExclusion: "Une liste personnalisée de noms/chemins de processus supplémentaires que le mod va exclure du ciblage. Cete liste est ajoutée à la liste d'exclusion que l'auteur du mod a défini pour déterminer quel processus cibler. Pour chaque processus, le mod est chargé si le chemin du processus correspond à l'un de ceux inclus et ne correspond à aucune de ceux exclus."
-        processListPlaceholder: "Noms/Chemins des processus, un par ligne, par exemple :"
+        processListPlaceholder: "Noms/chemins des processus, un par ligne, par exemple :"
         saveButton: "Sauvegarder"
       includeExcludeCustomOnly:
         title: "Ignorer les listes d'inclusion/exclusion de mods"
@@ -179,7 +179,7 @@ app:
     changes:
       title: "Changements de la dernière version"
       noData: "La version installée est identique à la dernière version."
-      splitView: "Séparer les vue"
+      splitView: "Séparer les vues"
       expandLines_one: "Développer une ligne cachée"
       expandLines_other: "Développer {{count}} lignes cachées"
   home:
@@ -215,7 +215,7 @@ app:
       description: "Afficher les actions pour développeur, comme créer et modifier des mods."
     advancedSettings: "Paramètres avancés"
     hideTrayIcon:
-      title: "Cacher l'icone de la zone de notification"
+      title: "Cacher l'icône de la zone de notification"
       description: "Vous devez désactiver cette option pour quitter Windhawk."
     requireElevation:
       title: "Contrôle de compte d’utilisateur (UAC) requis pour lancer Windhawk"
@@ -240,7 +240,7 @@ app:
       verbose: "Verbosité"
     processList:
       titleExclusion: "Liste d'exclusion de processus"
-      descriptionExclusion: "Une liste personnalisée de noms/chemins des processus dans lesquels Windhawk ne pourra rien injecter. Cela peut être utile dans les cas où Windhawk n'est pas compatible avec un programme spécifique. Notez qu'ajouter un processus à cette liste empêchera non seulement Windhawk de le personnaliser, mais empêchera également Windhawk d'intercepter les processus enfants créés par ce processus. Cela forcera Windhawk à charger les mods avec un léger retardement dans de tels cas."
+      descriptionExclusion: "Une liste personnalisée de noms/chemins de processus dans lesquels Windhawk ne pourra rien injecter. Cela peut être utile dans les cas où Windhawk n'est pas compatible avec un programme spécifique. Notez qu'ajouter un processus à cette liste empêchera non seulement Windhawk de le personnaliser, mais empêchera également Windhawk d'intercepter les processus enfants créés par ce processus. Cela forcera Windhawk à charger les mods avec un léger retardement dans de tels cas."
       exclusionCriticalProcessesNotice: "La valeur spéciale <0>{{critical_system_processes}}</0> peut être ajoutée à la liste d'exclusion des processus système critiques. Supprimez-le avec précaution, car faire crasher l'un de ces processus peut conduire à un BOSD (écran bleu)."
       titleInclusion: "Liste d'exclusion de processus"
       descriptionInclusion: "Une liste de noms/chemins de processus dans lesquels Windhawk vas pouvoir injecter du code, même s'ils sont dans la liste d'exclusion."
@@ -311,6 +311,6 @@ app:
     preview: "Prévisualier le mod"
     showLogOutput: "Montrer les sorties de log"
     exit: "Quitter le mode d'édition"
-    exitConfirmation: "Les changement effectués depuis la dernière compilation réussie vont être perdues"
+    exitConfirmation: "Les changements effectués depuis la dernière compilation réussie vont être perdus"
     exitButtonOk: "Quitter"
     exitButtonCancel: "Rester"

--- a/fr.yml
+++ b/fr.yml
@@ -36,7 +36,7 @@ setup:
 tray:
   TRAY_OPEN: "Ouvrir &Windhawk"
   TRAY_LOADED_MODS: "&Mods chargés"
-  TRAY_TOOLKIT: ~
+  TRAY_TOOLKIT: "&Boîte à outils"
   TRAY_EXIT: "&Quitter"
   EXITDLG_TITLE: "Quitter Windhawk"
   EXITDLG_CONTENT: "Windhawk va se fermer et tous les mods seront désactivés. Windhawk sera démarré automatiquement au prochain démarrage système, sauf si vous cochez l'option ci-dessous."
@@ -62,15 +62,15 @@ tray:
   TASKDLG_STATUS_UNLOADED: "Déchargé"
   TASKDLG_TASK_INITIALIZING: "Initialisation..."
   TASKDLG_TASK_LOADING_SYMBOLS: "Chargement des symboles..."
-  TOOLKITDLG_TITLE: ~
-  TOOLKITDLG_BUTTON_OPEN: ~
-  TOOLKITDLG_BUTTON_LOADED_MODS: ~
-  TOOLKITDLG_BUTTON_EXIT: ~
-  TOOLKITDLG_BUTTON_SAFE_MODE: ~
-  TOOLKITDLG_BUTTON_CLOSE: ~
-  SAFE_MODE_TITLE: ~
-  SAFE_MODE_TEXT: ~
-  TASKDLG_PROCESS_SUSPENDED: ~
+  TOOLKITDLG_TITLE: "Boîte à outils Windhawk"
+  TOOLKITDLG_BUTTON_OPEN: "&Ouvrir Windhawk"
+  TOOLKITDLG_BUTTON_LOADED_MODS: "Mods &chargés"
+  TOOLKITDLG_BUTTON_EXIT: "&Quitter Windhawk"
+  TOOLKITDLG_BUTTON_SAFE_MODE: "&Mode sans échec"
+  TOOLKITDLG_BUTTON_CLOSE: "&Fermer la boîte à outils"
+  SAFE_MODE_TITLE: "Redémarrer en mode sans échec"
+  SAFE_MODE_TEXT: "Windhawk va être relancé mais toutes les fonctions d'injection de code seront désactivées"
+  TASKDLG_PROCESS_SUSPENDED: "(suspendu)"
 app:
   general:
     loading: "Chargement..."
@@ -81,10 +81,10 @@ app:
     updating: "Mise à jour en cours..."
     installing: "Installation en cours..."
     compiling: "Compilation en cours..."
-    cut: ~
-    copy: ~
-    paste: ~
-    selectAll: ~
+    cut: "Couper"
+    copy: "Copier"
+    paste: "Coller"
+    selectAll: "Tout sélectionner"
   appHeader:
     home: "Accueil"
     explore: "Explorer"
@@ -221,8 +221,8 @@ app:
       title: "Contrôle de compte d’utilisateur (UAC) requis pour lancer Windhawk"
       description: "Windhawk requière des droits administrateur, mais pour un ordinateur ne comportant qu'un seul utilisateur, avoir l'invite de contrôle du compte d'utilisateur (UAC) à chaque fois peut être ennuyant, donc Windhawk la contourne. Activer cette option pour exiger l'invite de contrôle du compte de l'utilisateur (UAC) pour lancer Windhawk."
     dontAutoShowToolkit:
-      title: ~
-      description: ~
+      title: "Ne pas automatiquement afficher la boîte de dialogue de la boîte à outils"
+      description: "Par défaut, Windhawk affiche automatiquement la boîte de dialogue de la boîte à outils quand il détecte que la barre des tâches n'est pas accessible, à cause d'instabilités système ou autre. La boîte de dialogue permet de quitter Windhawk, passer en mode sans échec and effectuer d'autres opérations. Elle peut également être afficher à l'aide du raccourci clavier Ctrl+Win+W."
     modInitDialogDelay:
       title: "Délai de dialogue d'initialisation du mod"
       description: "Temps en millisecondes à attendre avant d'afficher les boîte de dialogue de progression pour initialiser le mod."
@@ -293,11 +293,11 @@ app:
     beginCodingButton: "Commencer le développement"
     cancelButton: "Annuler"
   safeMode:
-    alert: ~
-    offButton: ~
-    offConfirm: ~
-    offConfirmOk: ~
-    offConfirmCancel: ~
+    alert: "Windhawk s'exécute en mode sans échec, toutes les fonctions d'injection de code sont désactivées"
+    offButton: "Désactiver le mode sans échec"
+    offConfirm: "Windhawk va devoir redémarrer pour appliquer les paramètres"
+    offConfirmOk: "Redémarrer Windhawk"
+    offConfirmCancel: "Annuler"
   modPreview:
     actionUnavailable: "L'action n'est pas disponible en mode prévisualisation"
     notCompiled: "Le mod a besoin d'être compilé avant d'être prévisualisé"


### PR DESCRIPTION
Hi ramensoftware! Here some fixes for French translation file.

```
L12-14 - missing accents on "Sélectionnez"
L27 - in French, it's akward to mix plurial and singular together ("aucune des informations n'est écrite" is basically a mix of both tenses)
L174 - I don't understand why my predecessor changed that only here and nowhere else, it wasn't really needed
L182 - number mistake
L218 - in French, icon can be translated "icon" (in IT domain only) or "icône"
L243 - same as L174, it was changed here and nowhere else and wasn't really needed
L314 - gender and number mistakes
```